### PR TITLE
[2.0] Moved `illuminate/notifications` to the `require`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.0-dev"
+            "dev-master": "2.0-dev"
         },
         "laravel": {
             "providers": [

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,10 @@
     ],
     "require": {
         "php": "^7.1.3",
+        "illuminate/notifications": "~5.8",
         "nexmo/client": "^1.0"
     },
     "require-dev": {
-        "illuminate/notifications": "~5.7",
         "mockery/mockery": "^1.0",
         "phpunit/phpunit": "^7.0"
     },


### PR DESCRIPTION
- moved illuminate/notifications to the require, since in the laravel v5.8 notifications component will not require this module;
- change dev-master alias to 2.0-dev