### PR TITLE
[5.8] Use Facade::resolved() before extending channel

### DIFF
--- a/src/NexmoChannelServiceProvider.php
+++ b/src/NexmoChannelServiceProvider.php
@@ -4,6 +4,7 @@ namespace Illuminate\Notifications;
 
 use Nexmo\Client as NexmoClient;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Notifications\ChannelManager;
 use Illuminate\Support\Facades\Notification;
 use Nexmo\Client\Credentials\Basic as NexmoCredentials;
 
@@ -16,14 +17,16 @@ class NexmoChannelServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        Notification::extend('nexmo', function ($app) {
-            return new Channels\NexmoSmsChannel(
-                new NexmoClient(new NexmoCredentials(
-                    $this->app['config']['services.nexmo.key'],
-                    $this->app['config']['services.nexmo.secret']
-                )),
-                $this->app['config']['services.nexmo.sms_from']
-            );
+        Notification::resolved(function (ChannelManager $service) {
+            $service->extend('nexmo', function ($app) {
+                return new Channels\NexmoSmsChannel(
+                    new NexmoClient(new NexmoCredentials(
+                        $this->app['config']['services.nexmo.key'],
+                        $this->app['config']['services.nexmo.secret']
+                    )),
+                    $this->app['config']['services.nexmo.sms_from']
+                );
+            });
         });
     }
 }


### PR DESCRIPTION
This allow nexmo notification to only be loaded when/if the notification is resolved. Based on PR made to <https://github.com/laravel/framework/pull/26824>