### PR TITLE
Fix Notification service resolution in provider

### DIFF
--- a/src/NexmoChannelServiceProvider.php
+++ b/src/NexmoChannelServiceProvider.php
@@ -10,11 +10,11 @@ use Nexmo\Client\Credentials\Basic as NexmoCredentials;
 class NexmoChannelServiceProvider extends ServiceProvider
 {
     /**
-     * Register the service provider.
+     * Boot the service provider.
      *
      * @return void
      */
-    public function register()
+    public function boot()
     {
         Notification::extend('nexmo', function ($app) {
             return new Channels\NexmoSmsChannel(


### PR DESCRIPTION
`ChannelManager` should be resolved not in `register()` but in `boot()`.
**It will break application bootstrap** if `ChannelManager` is extended and the original `Illuminate\Notifications\NotificationServiceProvider` is replaced by `App\Providers\NotificationServiceProvider`.

```
Unresolvable dependency resolving [Parameter #0 [ <required> $app ]] in class Illuminate\Support\Manager
```

Related: https://github.com/laravel/slack-notification-channel/pull/10