### PR TITLE
Update to use newest version of nexmo/laravel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.1.3",
         "illuminate/notifications": "~5.8.0|^6.0|^7.0",
-        "nexmo/client": "^1.0|^2.0"
+        "nexmo/laravel": "^2.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/src/NexmoChannelServiceProvider.php
+++ b/src/NexmoChannelServiceProvider.php
@@ -5,7 +5,6 @@ namespace Illuminate\Notifications;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\ServiceProvider;
 use Nexmo\Client as NexmoClient;
-use Nexmo\Client\Credentials\Basic as NexmoCredentials;
 
 class NexmoChannelServiceProvider extends ServiceProvider
 {
@@ -19,10 +18,7 @@ class NexmoChannelServiceProvider extends ServiceProvider
         Notification::resolved(function (ChannelManager $service) {
             $service->extend('nexmo', function ($app) {
                 return new Channels\NexmoSmsChannel(
-                    new NexmoClient(new NexmoCredentials(
-                        $this->app['config']['services.nexmo.key'],
-                        $this->app['config']['services.nexmo.secret']
-                    )),
+                    $this->app->make(NexmoClient::class),
                     $this->app['config']['services.nexmo.sms_from']
                 );
             });


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

(This may be better suited for `master`. I'm not sure if Laravel considers this a BC-breaking change or not, since the underlying package is being changed.)

This switches this library over to using the [`nexmo/laravel`](https://github.com/nexmo/nexmo-laravel) package, and brings everything up to the 2.x line.

Switching to the `nexmo/laravel` allows the Nexmo client to be pulled directly from the Service Container, as opposed to being instantiated directly in the Channel Service Provider. `nexmo/laravel` also ships a Facade, giving the developers the option to use the Service Container or Facades to pull in a valid package if they want to use Nexmo in other places in their application.

We're recommending Laravel switch to use `nexmo/laravel` as it also gives users a workaround in case they run into GuzzleHTTP collisions in the future (see https://github.com/Nexmo/nexmo-php/issues/5). `nexmo/laravel` can easily be overridden to use a different HTTPlug-compatible adapter, where directly creating a `\Nexmo\Client` makes it much harder to override. 

Both `laravel/nexmo-notification-channel` and `nexmo/laravel` use the same `.env` options, so this should be a drop-in replacement for users. 

