### PR TITLE
[2.x] Implement shortcode support

### DIFF
--- a/src/Channels/NexmoShortcodeChannel.php
+++ b/src/Channels/NexmoShortcodeChannel.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Illuminate\Notifications\Channels;
+
+use Illuminate\Notifications\Notification;
+use Nexmo\Message\Client as NexmoClient;
+
+class NexmoShortcodeChannel
+{
+    /**
+     * The Nexmo client with keypair credentials.
+     *
+     * @var \Nexmo\Message\Client
+     */
+    protected $nexmo;
+
+    /**
+     * Create a new channel instance.
+     *
+     * @param  \Nexmo\Message\Client  $nexmo
+     * @return void
+     */
+    public function __construct(NexmoClient $nexmo)
+    {
+        $this->client = $nexmo;
+    }
+
+    /**
+     * Send the given notification.
+     *
+     * @param  mixed  $notifiable
+     * @param  \Illuminate\Notifications\Notification  $notification
+     * @return void
+     */
+    public function send($notifiable, Notification $notification)
+    {
+        if (! $to = $notifiable->routeNotificationFor('shortcode', $notification)) {
+            return;
+        }
+
+        $shortcode = array_merge(['to' => $to], $notification->toShortcode($notifiable));
+
+        $this->nexmo->sendShortcode($shortcode);
+    }
+}

--- a/src/Channels/NexmoShortcodeChannel.php
+++ b/src/Channels/NexmoShortcodeChannel.php
@@ -8,7 +8,7 @@ use Nexmo\Message\Client as NexmoClient;
 class NexmoShortcodeChannel
 {
     /**
-     * The Nexmo client with keypair credentials.
+     * The Nexmo message client instance.
      *
      * @var \Nexmo\Message\Client
      */

--- a/src/NexmoChannelServiceProvider.php
+++ b/src/NexmoChannelServiceProvider.php
@@ -5,6 +5,7 @@ namespace Illuminate\Notifications;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\ServiceProvider;
 use Nexmo\Client as NexmoClient;
+use Nexmo\Message\Client as NexmoMessageClient;
 
 class NexmoChannelServiceProvider extends ServiceProvider
 {
@@ -21,6 +22,14 @@ class NexmoChannelServiceProvider extends ServiceProvider
                     $this->app->make(NexmoClient::class),
                     $this->app['config']['services.nexmo.sms_from']
                 );
+            });
+
+            $service->extend('shortcode', function ($app) {
+                $client = tap($app->make(NexmoMessageClient::class), function ($client) use ($app) {
+                    $client->setClient($app->make(NexmoClient::class));
+                });
+
+                return new Channels\NexmoShortcodeChannel($client);
             });
         });
     }

--- a/tests/Channels/NexmoShortcodeChannelTest.php
+++ b/tests/Channels/NexmoShortcodeChannelTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Illuminate\Tests\Notifications\Channels;
+
+use Illuminate\Notifications\Channels\NexmoShortcodeChannel;
+use Illuminate\Notifications\Notifiable;
+use Illuminate\Notifications\Notification;
+use Illuminate\Tests\Notifications\TestCase;
+use Mockery as m;
+use Nexmo\Message\Client;
+
+class NexmoShortcodeChannelTest extends TestCase
+{
+    public function testShortcodeIsSentViaNexmo()
+    {
+        $notification = new NotificationNexmoShortcodeChannelTestNotification;
+        $notifiable = new NotificationNexmoShortcodeChannelTestNotifiable;
+
+        $channel = new NexmoShortcodeChannel(
+            $nexmo = m::mock(Client::class)
+        );
+
+        $nexmo->shouldReceive('sendShortcode')->with([
+            'type' => 'alert',
+            'to' => '5555555555',
+            'custom' => [
+                'code' => 'abc123'
+            ],
+        ]);
+
+        $channel->send($notifiable, $notification);
+    }
+}
+
+class NotificationNexmoShortcodeChannelTestNotifiable
+{
+    use Notifiable;
+
+    public $phone_number = '5555555555';
+}
+
+class NotificationNexmoShortcodeChannelTestNotification extends Notification
+{
+    public function toShortcode($notifiable)
+    {
+        return [
+            'type' => 'alert',
+            'custom' => [
+                'code' => 'abc123',
+            ],
+        ];
+    }
+}

--- a/tests/Channels/NexmoShortcodeChannelTest.php
+++ b/tests/Channels/NexmoShortcodeChannelTest.php
@@ -24,7 +24,7 @@ class NexmoShortcodeChannelTest extends TestCase
             'type' => 'alert',
             'to' => '5555555555',
             'custom' => [
-                'code' => 'abc123'
+                'code' => 'abc123',
             ],
         ]);
 

--- a/tests/Channels/NexmoSmsChannelTest.php
+++ b/tests/Channels/NexmoSmsChannelTest.php
@@ -12,11 +12,6 @@ use Nexmo\Client;
 
 class NexmoSmsChannelTest extends TestCase
 {
-    protected function tearDown(): void
-    {
-        m::close();
-    }
-
     public function testSmsIsSentViaNexmo()
     {
         $notification = new NotificationNexmoSmsChannelTestNotification;

--- a/tests/Channels/NexmoSmsChannelTest.php
+++ b/tests/Channels/NexmoSmsChannelTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Illuminate\Tests\Notifications;
+namespace Illuminate\Tests\Notifications\Channels;
 
 use Illuminate\Notifications\Channels\NexmoSmsChannel;
 use Illuminate\Notifications\Messages\NexmoMessage;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Notifications\Notification;
+use Illuminate\Tests\Notifications\TestCase;
 use Mockery as m;
 use Nexmo\Client;
-use PHPUnit\Framework\TestCase;
 
-class NotificationNexmoChannelTest extends TestCase
+class NexmoSmsChannelTest extends TestCase
 {
     protected function tearDown(): void
     {
@@ -19,8 +19,8 @@ class NotificationNexmoChannelTest extends TestCase
 
     public function testSmsIsSentViaNexmo()
     {
-        $notification = new NotificationNexmoChannelTestNotification;
-        $notifiable = new NotificationNexmoChannelTestNotifiable;
+        $notification = new NotificationNexmoSmsChannelTestNotification;
+        $notifiable = new NotificationNexmoSmsChannelTestNotifiable;
 
         $channel = new NexmoSmsChannel(
             $nexmo = m::mock(Client::class), '4444444444'
@@ -39,8 +39,8 @@ class NotificationNexmoChannelTest extends TestCase
 
     public function testSmsIsSentViaNexmoWithCustomFrom()
     {
-        $notification = new NotificationNexmoChannelTestCustomFromNotification;
-        $notifiable = new NotificationNexmoChannelTestNotifiable;
+        $notification = new NotificationNexmoSmsChannelTestCustomFromNotification;
+        $notifiable = new NotificationNexmoSmsChannelTestNotifiable;
 
         $channel = new NexmoSmsChannel(
             $nexmo = m::mock(Client::class), '4444444444'
@@ -59,8 +59,8 @@ class NotificationNexmoChannelTest extends TestCase
 
     public function testSmsIsSentViaNexmoWithCustomFromAndClientRef()
     {
-        $notification = new NotificationNexmoChannelTestCustomFromAndClientRefNotification;
-        $notifiable = new NotificationNexmoChannelTestNotifiable;
+        $notification = new NotificationNexmoSmsChannelTestCustomFromAndClientRefNotification;
+        $notifiable = new NotificationNexmoSmsChannelTestNotifiable;
 
         $channel = new NexmoSmsChannel(
             $nexmo = m::mock(Client::class), '4444444444'
@@ -78,14 +78,14 @@ class NotificationNexmoChannelTest extends TestCase
     }
 }
 
-class NotificationNexmoChannelTestNotifiable
+class NotificationNexmoSmsChannelTestNotifiable
 {
     use Notifiable;
 
     public $phone_number = '5555555555';
 }
 
-class NotificationNexmoChannelTestNotification extends Notification
+class NotificationNexmoSmsChannelTestNotification extends Notification
 {
     public function toNexmo($notifiable)
     {
@@ -93,7 +93,7 @@ class NotificationNexmoChannelTestNotification extends Notification
     }
 }
 
-class NotificationNexmoChannelTestCustomFromNotification extends Notification
+class NotificationNexmoSmsChannelTestCustomFromNotification extends Notification
 {
     public function toNexmo($notifiable)
     {
@@ -101,7 +101,7 @@ class NotificationNexmoChannelTestCustomFromNotification extends Notification
     }
 }
 
-class NotificationNexmoChannelTestCustomFromAndClientRefNotification extends Notification
+class NotificationNexmoSmsChannelTestCustomFromAndClientRefNotification extends Notification
 {
     public function toNexmo($notifiable)
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Illuminate\Tests\Notifications;
+
+use Mockery as m;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
+class TestCase extends BaseTestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,16 +2,10 @@
 
 namespace Illuminate\Tests\Notifications;
 
-use Mockery as m;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
     use MockeryPHPUnitIntegration;
-
-    protected function tearDown(): void
-    {
-        m::close();
-    }
 }


### PR DESCRIPTION
As suggested in #13, this implements shortcode support with Nexmo. Pulled this out of our app to break off into a package but would be better in the official notification channel.

A couple of notes: -
* I called the channel `shortcode` for brevity, but it isn't quite as "namespaced" as the `nexmo` channel. I'm not sure there is a precedent for multi-word channel names - would `nexmo-shortcode` be better? 

* At the moment I've implemented it with support for an array which `Nexmo\Message\Shortcode` will adapt into an instance under the hood. Would you want me to implement a fluent interface to build up a shortcode message as well?

* I added a base TestCase that uses `MockeryPHPUnitIntegration` - this fixes an issue with PHPUnit complaining that the tests didn't actually perform any assertions (despite the fact they set expectations on mocks).

```
1) Illuminate\Tests\Notifications\Channels\NexmoShortcodeChannelTest::testShortcodeIsSentViaNexmo
This test did not perform any assertions
```

Happy to sort out a PR for the docs as well if you decide to bring this in.