### PR TITLE
[2.0] Fix shortcode implementation and test coverage

### DIFF
--- a/src/Channels/NexmoShortcodeChannel.php
+++ b/src/Channels/NexmoShortcodeChannel.php
@@ -22,7 +22,7 @@ class NexmoShortcodeChannel
      */
     public function __construct(NexmoClient $nexmo)
     {
-        $this->client = $nexmo;
+        $this->nexmo = $nexmo;
     }
 
     /**

--- a/tests/Channels/NexmoShortcodeChannelTest.php
+++ b/tests/Channels/NexmoShortcodeChannelTest.php
@@ -20,13 +20,15 @@ class NexmoShortcodeChannelTest extends TestCase
             $nexmo = m::mock(Client::class)
         );
 
-        $nexmo->shouldReceive('sendShortcode')->with([
-            'type' => 'alert',
-            'to' => '5555555555',
-            'custom' => [
-                'code' => 'abc123',
-            ],
-        ]);
+        $nexmo->shouldReceive('sendShortcode')
+            ->with([
+                'type' => 'alert',
+                'to' => '5555555555',
+                'custom' => [
+                    'code' => 'abc123',
+                ],
+            ])
+            ->once();
 
         $channel->send($notifiable, $notification);
     }
@@ -37,6 +39,11 @@ class NotificationNexmoShortcodeChannelTestNotifiable
     use Notifiable;
 
     public $phone_number = '5555555555';
+
+    public function routeNotificationForShortcode($notification)
+    {
+        return $this->phone_number;
+    }
 }
 
 class NotificationNexmoShortcodeChannelTestNotification extends Notification

--- a/tests/Channels/NexmoSmsChannelTest.php
+++ b/tests/Channels/NexmoSmsChannelTest.php
@@ -21,13 +21,15 @@ class NexmoSmsChannelTest extends TestCase
             $nexmo = m::mock(Client::class), '4444444444'
         );
 
-        $nexmo->shouldReceive('message->send')->with([
-            'type' => 'text',
-            'from' => '4444444444',
-            'to' => '5555555555',
-            'text' => 'this is my message',
-            'client_ref' => '',
-        ]);
+        $nexmo->shouldReceive('message->send')
+            ->with([
+                'type' => 'text',
+                'from' => '4444444444',
+                'to' => '5555555555',
+                'text' => 'this is my message',
+                'client_ref' => '',
+            ])
+            ->once();
 
         $channel->send($notifiable, $notification);
     }
@@ -41,13 +43,15 @@ class NexmoSmsChannelTest extends TestCase
             $nexmo = m::mock(Client::class), '4444444444'
         );
 
-        $nexmo->shouldReceive('message->send')->with([
-            'type' => 'unicode',
-            'from' => '5554443333',
-            'to' => '5555555555',
-            'text' => 'this is my message',
-            'client_ref' => '',
-        ]);
+        $nexmo->shouldReceive('message->send')
+            ->with([
+                'type' => 'unicode',
+                'from' => '5554443333',
+                'to' => '5555555555',
+                'text' => 'this is my message',
+                'client_ref' => '',
+            ])
+            ->once();
 
         $channel->send($notifiable, $notification);
     }
@@ -61,13 +65,15 @@ class NexmoSmsChannelTest extends TestCase
             $nexmo = m::mock(Client::class), '4444444444'
         );
 
-        $nexmo->shouldReceive('message->send')->with([
-            'type' => 'unicode',
-            'from' => '5554443333',
-            'to' => '5555555555',
-            'text' => 'this is my message',
-            'client_ref' => '11',
-        ]);
+        $nexmo->shouldReceive('message->send')
+            ->with([
+                'type' => 'unicode',
+                'from' => '5554443333',
+                'to' => '5555555555',
+                'text' => 'this is my message',
+                'client_ref' => '11',
+            ])
+            ->once();
 
         $channel->send($notifiable, $notification);
     }
@@ -78,6 +84,11 @@ class NotificationNexmoSmsChannelTestNotifiable
     use Notifiable;
 
     public $phone_number = '5555555555';
+
+    public function routeNotificationForNexmo($notification)
+    {
+        return $this->phone_number;
+    }
 }
 
 class NotificationNexmoSmsChannelTestNotification extends Notification


### PR DESCRIPTION
I found a really silly bug in the shortcode channel (sorry) that assigned the argument to the wrong instance variable. It seems the test coverage didn't pick it up as Mockery didn't specify the number of times each mock should be called.

I've updated the mocks to ensure that they are called once as expected, and also implemented `routeNotificationFor*` methods in the stub notifiables so the tests are actually performed to completion.