### PR TITLE
[1.x] Fixes deps requirements for nexmo/client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "nexmo/client": "^1.0"
+        "nexmo/client-core": "^1.0",
+        "php-http/guzzle6-adapter": "^1.0"
     },
     "require-dev": {
         "illuminate/notifications": "~5.7",


### PR DESCRIPTION
Schedule build for Testbench for Laravel 5.7 start showing failure today due to changes to `nexmo/client`.

<img width="1263" alt="Screenshot 2019-11-26 at 2 22 56 PM" src="https://user-images.githubusercontent.com/172966/69604457-7daede00-1058-11ea-8521-c7dae0ac7c99.png">

This doesn't affect v2.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
