### PR TITLE
[2.x] Allow to override Nexmo client via NexmoMessage

### DIFF
--- a/src/Channels/NexmoSmsChannel.php
+++ b/src/Channels/NexmoSmsChannel.php
@@ -54,7 +54,7 @@ class NexmoSmsChannel
             $message = new NexmoMessage($message);
         }
 
-        return $this->nexmo->message()->send([
+        return ($message->client ?? $this->nexmo)->message()->send([
             'type' => $message->type,
             'from' => $message->from ?: $this->from,
             'to' => $to,

--- a/src/Messages/NexmoMessage.php
+++ b/src/Messages/NexmoMessage.php
@@ -33,6 +33,13 @@ class NexmoMessage
     public $clientReference = '';
 
     /**
+     * The custom Nexmo client.
+     *
+     * @var \Nexmo\Client|null
+     */
+    public $client;
+
+    /**
      * Create a new message instance.
      *
      * @param  string  $content
@@ -90,6 +97,19 @@ class NexmoMessage
     public function clientReference($clientReference)
     {
         $this->clientReference = $clientReference;
+
+        return $this;
+    }
+
+    /**
+     * Set the Nexmo client instance.
+     *
+     * @param  \Nexmo\Client  $clientReference
+     * @return $this
+     */
+    public function via($client)
+    {
+        $this->client = $client;
 
         return $this;
     }

--- a/tests/Channels/NexmoSmsChannelTest.php
+++ b/tests/Channels/NexmoSmsChannelTest.php
@@ -34,6 +34,31 @@ class NexmoSmsChannelTest extends TestCase
         $channel->send($notifiable, $notification);
     }
 
+    public function testSmsIsSentViaNexmoWithCustomClient()
+    {
+        $customNexmo = m::mock(Client::class);
+        $customNexmo->shouldReceive('message->send')
+            ->with([
+                'type' => 'text',
+                'from' => '4444444444',
+                'to' => '5555555555',
+                'text' => 'this is my message',
+                'client_ref' => '',
+            ])
+            ->once();
+
+        $notification = new NotificationNexmoSmsChannelTestCustomClientNotification($customNexmo);
+        $notifiable = new NotificationNexmoSmsChannelTestNotifiable;
+
+        $channel = new NexmoSmsChannel(
+            $nexmo = m::mock(Client::class), '4444444444'
+        );
+
+        $nexmo->shouldNotReceive('message->send');
+
+        $channel->send($notifiable, $notification);
+    }
+
     public function testSmsIsSentViaNexmoWithCustomFrom()
     {
         $notification = new NotificationNexmoSmsChannelTestCustomFromNotification;
@@ -52,6 +77,31 @@ class NexmoSmsChannelTest extends TestCase
                 'client_ref' => '',
             ])
             ->once();
+
+        $channel->send($notifiable, $notification);
+    }
+
+    public function testSmsIsSentViaNexmoWithCustomFromAndClient()
+    {
+        $customNexmo = m::mock(Client::class);
+        $customNexmo->shouldReceive('message->send')
+            ->with([
+                'type' => 'unicode',
+                'from' => '5554443333',
+                'to' => '5555555555',
+                'text' => 'this is my message',
+                'client_ref' => '',
+            ])
+            ->once();
+
+        $notification = new NotificationNexmoSmsChannelTestCustomFromAndClientNotification($customNexmo);
+        $notifiable = new NotificationNexmoSmsChannelTestNotifiable;
+
+        $channel = new NexmoSmsChannel(
+            $nexmo = m::mock(Client::class), '4444444444'
+        );
+
+        $nexmo->shouldNotReceive('message->send');
 
         $channel->send($notifiable, $notification);
     }
@@ -77,6 +127,31 @@ class NexmoSmsChannelTest extends TestCase
 
         $channel->send($notifiable, $notification);
     }
+
+    public function testSmsIsSentViaNexmoWithCustomClientFromAndClientRef()
+    {
+        $customNexmo = m::mock(Client::class);
+        $customNexmo->shouldReceive('message->send')
+            ->with([
+                'type' => 'unicode',
+                'from' => '5554443333',
+                'to' => '5555555555',
+                'text' => 'this is my message',
+                'client_ref' => '11',
+            ])
+            ->once();
+
+        $notification = new NotificationNexmoSmsChannelTestCustomClientFromAndClientRefNotification($customNexmo);
+        $notifiable = new NotificationNexmoSmsChannelTestNotifiable;
+
+        $channel = new NexmoSmsChannel(
+            $nexmo = m::mock(Client::class), '4444444444'
+        );
+
+        $nexmo->shouldNotReceive('message->send');
+
+        $channel->send($notifiable, $notification);
+    }
 }
 
 class NotificationNexmoSmsChannelTestNotifiable
@@ -99,6 +174,21 @@ class NotificationNexmoSmsChannelTestNotification extends Notification
     }
 }
 
+class NotificationNexmoSmsChannelTestCustomClientNotification extends Notification
+{
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function toNexmo($notifiable)
+    {
+        return (new NexmoMessage('this is my message'))->via($this->client);
+    }
+}
+
 class NotificationNexmoSmsChannelTestCustomFromNotification extends Notification
 {
     public function toNexmo($notifiable)
@@ -107,10 +197,44 @@ class NotificationNexmoSmsChannelTestCustomFromNotification extends Notification
     }
 }
 
+class NotificationNexmoSmsChannelTestCustomFromAndClientNotification extends Notification
+{
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function toNexmo($notifiable)
+    {
+        return (new NexmoMessage('this is my message'))->from('5554443333')->unicode()->via($this->client);
+    }
+}
+
 class NotificationNexmoSmsChannelTestCustomFromAndClientRefNotification extends Notification
 {
     public function toNexmo($notifiable)
     {
         return (new NexmoMessage('this is my message'))->from('5554443333')->unicode()->clientReference('11');
+    }
+}
+
+class NotificationNexmoSmsChannelTestCustomClientFromAndClientRefNotification extends Notification
+{
+    private $client;
+
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+    }
+
+    public function toNexmo($notifiable)
+    {
+        return (new NexmoMessage('this is my message'))
+            ->from('5554443333')
+            ->unicode()
+            ->clientReference('11')
+            ->via($this->client);
     }
 }


### PR DESCRIPTION
This PR adds ability to override underlying `Nexmo\Client` instance with custom client. This helps in situations when you have some customer/DB-stored credentials and you need to send SMS using given credentials (not with the system-wide that are stored in `services.php`).

Example code:

```php
<?php

declare(strict_types=1);

namespace App\Notifications;

use Illuminate\Notifications\Messages\NexmoMessage;
use Illuminate\Notifications\Notification;
use App\Models\Company;
use Nexmo\Client;

class ExampleNotification extends Notification
{
    private Company $company;

    public function __construct(Company $company)
    {
        $this->company = $company;
    }

    public function toNexmo($notifiable): NexmoMessage
    {
        return (new NexmoMessage('Something happened!'))
            ->from($this->company->nexmo_from)
            ->via($this->getCompanyClient());
    }

    private function getCompanyClient(): Client
    {
        return new Client(
            new Client\Credentials\Basic(
                $this->company->nexmo_key,
                $this->company->nexmo_secret
            )
        );
    }
}
```