### PR TITLE
[2.x] Fix shortcode messaging with the latest version of nexmo-client

### DIFF
--- a/src/NexmoChannelServiceProvider.php
+++ b/src/NexmoChannelServiceProvider.php
@@ -25,7 +25,7 @@ class NexmoChannelServiceProvider extends ServiceProvider
             });
 
             $service->extend('shortcode', function ($app) {
-                $client = tap($app->make(NexmoMessageClient::class), function ($client) use ($app) {
+                $client = tap(new NexmoMessageClient, function ($client) use ($app) {
                     $client->setClient($app->make(NexmoClient::class));
                 });
 


### PR DESCRIPTION
With the latest release(s) of `nexmo-client` (v2.2.0+) they've made some changes internally, which affect how `Nexmo\Message\Client` uses the `Nexmo\Client` that is passed into it. This breaks the ability to send shortcodes when you have the latest versions of `nexmo-client`.

Previously I used the container to create a new instance of `Nexmo\Message\Client` and Laravel was being smart and giving it an instance of an optional dependency. However, this optional dependency now overrides the custom `Nexmo\Client` we're setting here.

The easy fix is to just not provide the optional dependency and new up the instance as-is. Alternatively I could register it directly with the service provider so it knows not to pass any dependency but that felt like overkill in this instance.