### PR TITLE
[2.x] Add functionality to process callbacks.

### DIFF
--- a/src/Channels/NexmoSmsChannel.php
+++ b/src/Channels/NexmoSmsChannel.php
@@ -60,6 +60,7 @@ class NexmoSmsChannel
             'to' => $to,
             'text' => trim($message->content),
             'client_ref' => $message->clientReference,
+            'callback' => $message->statusCallback,
         ]);
     }
 }

--- a/src/Messages/NexmoMessage.php
+++ b/src/Messages/NexmoMessage.php
@@ -109,19 +109,6 @@ class NexmoMessage
     }
 
     /**
-     * Set the Nexmo client instance.
-     *
-     * @param  \Nexmo\Client  $clientReference
-     * @return $this
-     */
-    public function usingClient($client)
-    {
-        $this->client = $client;
-
-        return $this;
-    }
-
-    /**
      * Set the webhook callback URL to update the message status.
      *
      * @param  string  $callback
@@ -130,6 +117,19 @@ class NexmoMessage
     public function statusCallback(string $callback)
     {
         $this->statusCallback = $callback;
+
+        return $this;
+    }    
+
+    /**
+     * Set the Nexmo client instance.
+     *
+     * @param  \Nexmo\Client  $clientReference
+     * @return $this
+     */
+    public function usingClient($client)
+    {
+        $this->client = $client;
 
         return $this;
     }

--- a/src/Messages/NexmoMessage.php
+++ b/src/Messages/NexmoMessage.php
@@ -40,6 +40,13 @@ class NexmoMessage
     public $clientReference = '';
 
     /**
+     * The webhook to be called with status updates.
+     *
+     * @var string
+     */
+    public $statusCallback = '';
+
+    /**
      * Create a new message instance.
      *
      * @param  string  $content
@@ -110,6 +117,19 @@ class NexmoMessage
     public function usingClient($client)
     {
         $this->client = $client;
+
+        return $this;
+    }
+
+    /**
+     * Set the webhook callback URL to update the message status.
+     *
+     * @param  string $callback
+     * @return        $this
+     */
+    public function statusCallback(string $callback)
+    {
+        $this->statusCallback = $callback;
 
         return $this;
     }

--- a/src/Messages/NexmoMessage.php
+++ b/src/Messages/NexmoMessage.php
@@ -124,8 +124,8 @@ class NexmoMessage
     /**
      * Set the webhook callback URL to update the message status.
      *
-     * @param  string $callback
-     * @return        $this
+     * @param  string  $callback
+     * @return $this
      */
     public function statusCallback(string $callback)
     {


### PR DESCRIPTION
This allows handling of contextual callbacks, so that status updates may be associated with a notification that has been sent out.

For example:
```php
    public function toNexmo(Communication $notifiable): NexmoMessage
    {
        return (new NexmoMessage)
            ->statusCallback(url("api/webhooks/nexmo/status/{$notifiable->getKey()}"))
            ->from(config("services.nexmo.sms_from"))
            ->content($notifiable->message);
    }
```

This will allow for the storage of status updates for the notification to be stored, perhaps like so:
```php
        (new NexmoWebhookLog)
            ->create([
                "api_key" => $this->input("api-key"),
                "communication_id" => $this->communication->getKey(),
                "err_code" => $this->input("err-code"),
                "message_timestamp" => $this->input("message-timestamp"),
                "messageId" => $this->messageId,
                "msisdn" => $this->msisdn,
                "network_code" => $this->input("network-code"),
                "price" => $this->price,
                "scts" => $this->scts,
                "status" => $this->status,
                "to" => $this->to,
            ]);
```
