### PR TITLE
[2.x] Fix callback not being applied

### DIFF
--- a/src/Channels/NexmoSmsChannel.php
+++ b/src/Channels/NexmoSmsChannel.php
@@ -63,7 +63,7 @@ class NexmoSmsChannel
         ];
 
         if ($message->statusCallback) {
-            $payload['client_ref'] = $message->clientReference;
+            $payload['callback'] = $message->statusCallback;
         }
 
         return ($message->client ?? $this->nexmo)->message()->send($payload);

--- a/tests/Channels/NexmoSmsChannelTest.php
+++ b/tests/Channels/NexmoSmsChannelTest.php
@@ -152,6 +152,29 @@ class NexmoSmsChannelTest extends TestCase
 
         $channel->send($notifiable, $notification);
     }
+
+    public function testCallbackIsApplied()
+    {
+        $notification = new NotificationNexmoSmsChannelTestCallback;
+        $notifiable = new NotificationNexmoSmsChannelTestNotifiable;
+
+        $channel = new NexmoSmsChannel(
+            $nexmo = m::mock(Client::class), '4444444444'
+        );
+
+        $nexmo->shouldReceive('message->send')
+            ->with([
+                'type' => 'text',
+                'from' => '4444444444',
+                'to' => '5555555555',
+                'text' => 'this is my message',
+                'client_ref' => '',
+                'callback' => 'https://example.com',
+            ])
+            ->once();
+
+        $channel->send($notifiable, $notification);
+    }
 }
 
 class NotificationNexmoSmsChannelTestNotifiable
@@ -236,5 +259,14 @@ class NotificationNexmoSmsChannelTestCustomClientFromAndClientRefNotification ex
             ->unicode()
             ->clientReference('11')
             ->usingClient($this->client);
+    }
+}
+
+class NotificationNexmoSmsChannelTestCallback extends Notification
+{
+    public function toNexmo($notifiable)
+    {
+        return (new NexmoMessage('this is my message'))
+            ->statusCallback('https://example.com');
     }
 }


### PR DESCRIPTION
Seems like this got broken in https://github.com/laravel/nexmo-notification-channel/commit/f124a4db6a7824251aa065d83389995745805bc0

Added a test for the callback to make sure it doesn't breaks again.