### PR TITLE
Remove unused dependency on composer/package-versions-deprecated

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require": {
         "php": "^7.1.3|^8.0",
-        "composer/package-versions-deprecated": "^1.8",
         "illuminate/notifications": "~5.8.0|^6.0|^7.0|^8.0",
         "nexmo/laravel": "^2.4"
     },


### PR DESCRIPTION
This package is a composer plugin that users have to allow explicitly in composer 2.2+ so the unused dependency will annoy users. Thus, for composer 2+, using composer-runtime-api is preferred (see https://github.com/symfony/symfony/issues/44726 for a discussion about fading out this package).