### PR TITLE
Switch Vonage to sms() method

### DIFF
--- a/src/Channels/VonageSmsChannel.php
+++ b/src/Channels/VonageSmsChannel.php
@@ -5,6 +5,7 @@ namespace Illuminate\Notifications\Channels;
 use Illuminate\Notifications\Messages\VonageMessage;
 use Illuminate\Notifications\Notification;
 use Vonage\Client as VonageClient;
+use Vonage\SMS\Message\SMS;
 
 class VonageSmsChannel
 {
@@ -54,18 +55,15 @@ class VonageSmsChannel
             $message = new VonageMessage($message);
         }
 
-        $payload = [
-            'type' => $message->type,
-            'from' => $message->from ?: $this->from,
-            'to' => $to,
-            'text' => trim($message->content),
-            'client-ref' => $message->clientReference,
-        ];
+        $sms = new SMS(
+            $to,
+            $message->from ?: $this->from,
+            trim($message->content),
+            $message->type
+        );
 
-        if ($message->statusCallback) {
-            $payload['callback'] = $message->statusCallback;
-        }
+        $sms->setClientRef($message->clientReference);
 
-        return ($message->client ?? $this->client)->message()->send($payload);
+        return ($message->client ?? $this->client)->sms()->send($sms);
     }
 }


### PR DESCRIPTION
Vonage is removing message() method. We can use the sms() method instead.

From what I understand, the statusCallback is not used on this channel. It's only for Slack notification so I havn't tried to handle it.

Closes https://github.com/laravel/vonage-notification-channel/issues/60

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
