### PR TITLE
dx: bind VonageSmsChannel to container

### DIFF
--- a/src/VonageChannelServiceProvider.php
+++ b/src/VonageChannelServiceProvider.php
@@ -35,12 +35,16 @@ class VonageChannelServiceProvider extends ServiceProvider
             return Vonage::make($app['config']['vonage'], $httpClient)->client();
         });
 
+        $this->app->bind(VonageSmsChannel::class, function ($app) {
+            return new VonageSmsChannel(
+                $app->make(Client::class),
+                $app['config']['vonage.sms_from']
+            );
+        });
+
         Notification::resolved(function (ChannelManager $service) {
             $service->extend('vonage', function ($app) {
-                return new VonageSmsChannel(
-                    $app->make(Client::class),
-                    $app['config']['vonage.sms_from']
-                );
+                return $app->make(VonageSmsChannel::class);
             });
         });
     }


### PR DESCRIPTION
Hi @driesvints ,

This change allow us to specify the channel class in Notification via() method.

```php
use Illuminate\Notifications\VonageSmsChannel;

public function via() {
   return [VonageSmsChannel::class]
}
```

The old syntax will still work

```php
public function via() {
   return ['vonage']
}
```
This helps us to CTRL+Click on class name and jump to actual class
