### PR TITLE
Swap Vonage Client to SMS instead of legacy message

### DIFF
--- a/src/Channels/VonageSmsChannel.php
+++ b/src/Channels/VonageSmsChannel.php
@@ -5,6 +5,7 @@ namespace Illuminate\Notifications\Channels;
 use Illuminate\Notifications\Messages\VonageMessage;
 use Illuminate\Notifications\Notification;
 use Vonage\Client as VonageClient;
+use Vonage\SMS\Message\SMS;
 
 class VonageSmsChannel
 {
@@ -54,18 +55,18 @@ class VonageSmsChannel
             $message = new VonageMessage($message);
         }
 
-        $payload = [
-            'type' => $message->type,
-            'from' => $message->from ?: $this->from,
-            'to' => $to,
-            'text' => trim($message->content),
-            'client-ref' => $message->clientReference,
-        ];
+        $vonageSms = new SMS(
+            $to,
+            $message->from ?: $this->from,
+            trim($message->content)
+        );
+
+        $vonageSms->setClientRef($message->clientReference);
 
         if ($message->statusCallback) {
-            $payload['callback'] = $message->statusCallback;
+            $vonageSms->setDeliveryReceiptCallback($message->statusCallback);
         }
 
-        return ($message->client ?? $this->client)->message()->send($payload);
+        return ($message->client ?? $this->client)->sms()->send($vonageSms);
     }
 }

--- a/tests/Unit/Channels/VonageSmsChannelTest.php
+++ b/tests/Unit/Channels/VonageSmsChannelTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Notifications\Tests\Unit\Channels;
 
+use Hamcrest\Core\IsEqual;
 use Illuminate\Notifications\Channels\VonageSmsChannel;
 use Illuminate\Notifications\Messages\VonageMessage;
 use Illuminate\Notifications\Notifiable;
@@ -10,6 +11,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Vonage\Client;
+use Vonage\SMS\Message\SMS;
 
 class VonageSmsChannelTest extends TestCase
 {
@@ -24,14 +26,14 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'text',
-                'from' => '4444444444',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '',
-            ])
+        $mockSms = (new SMS(
+            '5555555555',
+            '4444444444',
+            'this is my message'
+        ));
+
+        $vonage->shouldReceive('sms->send')
+            ->with(IsEqual::equalTo($mockSms))
             ->once();
 
         $channel->send($notifiable, $notification);
@@ -40,14 +42,12 @@ class VonageSmsChannelTest extends TestCase
     public function testSmsIsSentViaVonageWithCustomClient()
     {
         $customVonage = m::mock(Client::class);
-        $customVonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'text',
-                'from' => '4444444444',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '',
-            ])
+        $customVonage->shouldReceive('sms->send')
+            ->with(IsEqual::equalTo(new SMS(
+                '5555555555',
+                '4444444444',
+                'this is my message'
+            )))
             ->once();
 
         $notification = new NotificationVonageSmsChannelTestCustomClientNotification($customVonage);
@@ -57,7 +57,7 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldNotReceive('message->send');
+        $vonage->shouldNotReceive('sms->send');
 
         $channel->send($notifiable, $notification);
     }
@@ -71,14 +71,14 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'unicode',
-                'from' => '5554443333',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '',
-            ])
+        $mockSms = (new SMS(
+            '5555555555',
+            '5554443333',
+            'this is my message'
+        ));
+
+        $vonage->shouldReceive('sms->send')
+            ->with(IsEqual::equalTo($mockSms))
             ->once();
 
         $channel->send($notifiable, $notification);
@@ -87,14 +87,16 @@ class VonageSmsChannelTest extends TestCase
     public function testSmsIsSentViaVonageWithCustomFromAndClient()
     {
         $customVonage = m::mock(Client::class);
-        $customVonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'unicode',
-                'from' => '5554443333',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '',
-            ])
+
+        $mockSms = new SMS(
+            '5555555555',
+            '5554443333',
+            'this is my message',
+            'unicode'
+        );
+
+        $customVonage->shouldReceive('sms->send')
+            ->with(IsEqual::equalTo($mockSms))
             ->once();
 
         $notification = new NotificationVonageSmsChannelTestCustomFromAndClientNotification($customVonage);
@@ -104,7 +106,7 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldNotReceive('message->send');
+        $vonage->shouldNotReceive('sms->send');
 
         $channel->send($notifiable, $notification);
     }
@@ -118,14 +120,17 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'unicode',
-                'from' => '5554443333',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '11',
-            ])
+        $mockSms = new SMS(
+            '5555555555',
+            '5554443333',
+            'this is my message',
+            'unicode'
+        );
+
+        $mockSms->setClientRef('11');
+
+        $vonage->shouldReceive('sms->send')
+            ->with(IsEqual::equalTo($mockSms))
             ->once();
 
         $channel->send($notifiable, $notification);
@@ -134,14 +139,18 @@ class VonageSmsChannelTest extends TestCase
     public function testSmsIsSentViaVonageWithCustomClientFromAndClientRef()
     {
         $customVonage = m::mock(Client::class);
-        $customVonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'unicode',
-                'from' => '5554443333',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '11',
-            ])
+
+        $mockSms = new SMS(
+            '5555555555',
+            '5554443333',
+            'this is my message',
+            'unicode'
+        );
+
+        $mockSms->setClientRef('11');
+
+        $customVonage->shouldReceive('sms->send')
+            ->with(IsEqual::equalTo($mockSms))
             ->once();
 
         $notification = new NotificationVonageSmsChannelTestCustomClientFromAndClientRefNotification($customVonage);
@@ -151,7 +160,7 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldNotReceive('message->send');
+        $vonage->shouldNotReceive('sms->send');
 
         $channel->send($notifiable, $notification);
     }
@@ -165,16 +174,17 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'text',
-                'from' => '4444444444',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '',
-                'callback' => 'https://example.com',
-            ])
-            ->once();
+        $mockSms = (new SMS(
+            '5555555555',
+            '4444444444',
+            'this is my message'
+        ));
+
+        $mockSms->setDeliveryReceiptCallback('https://example.com');
+
+        $vonage->shouldReceive('sms->send')
+               ->with(IsEqual::equalTo($mockSms))
+               ->once();
 
         $channel->send($notifiable, $notification);
     }
@@ -269,7 +279,6 @@ class NotificationVonageSmsChannelTestCallback extends Notification
 {
     public function toVonage($notifiable)
     {
-        return (new VonageMessage('this is my message'))
-            ->statusCallback('https://example.com');
+        return (new VonageMessage('this is my message'))->statusCallback('https://example.com');
     }
 }


### PR DESCRIPTION
This PR changes the notification channel to use the more modern Vonage SMS client which contains slightly different logic than the legacy message client - We now have value objects for SMS messages.

It also allows for the dropping of the legacy message client in the Vonage core library, which has been marked as deprecated since 3.0

Tests have been updated accordingly.