### PR TITLE
Fix the type of the message to save a lot of money 💸

### DIFF
--- a/src/Channels/VonageSmsChannel.php
+++ b/src/Channels/VonageSmsChannel.php
@@ -58,7 +58,8 @@ class VonageSmsChannel
         $vonageSms = new SMS(
             $to,
             $message->from ?: $this->from,
-            trim($message->content)
+            trim($message->content),
+            $message->type
         );
 
         $vonageSms->setClientRef($message->clientReference);

--- a/tests/Unit/Channels/VonageSmsChannelTest.php
+++ b/tests/Unit/Channels/VonageSmsChannelTest.php
@@ -29,7 +29,8 @@ class VonageSmsChannelTest extends TestCase
         $mockSms = (new SMS(
             '5555555555',
             '4444444444',
-            'this is my message'
+            'this is my message',
+            'text'
         ));
 
         $vonage->shouldReceive('sms->send')
@@ -46,7 +47,8 @@ class VonageSmsChannelTest extends TestCase
             ->with(IsEqual::equalTo(new SMS(
                 '5555555555',
                 '4444444444',
-                'this is my message'
+                'this is my message',
+                'text'
             )))
             ->once();
 
@@ -74,7 +76,8 @@ class VonageSmsChannelTest extends TestCase
         $mockSms = (new SMS(
             '5555555555',
             '5554443333',
-            'this is my message'
+            'this is my message',
+            'text'
         ));
 
         $vonage->shouldReceive('sms->send')
@@ -177,7 +180,8 @@ class VonageSmsChannelTest extends TestCase
         $mockSms = (new SMS(
             '5555555555',
             '4444444444',
-            'this is my message'
+            'this is my message',
+            'text'
         ));
 
         $mockSms->setDeliveryReceiptCallback('https://example.com');

--- a/tests/Unit/Channels/VonageSmsChannelTest.php
+++ b/tests/Unit/Channels/VonageSmsChannelTest.php
@@ -76,8 +76,7 @@ class VonageSmsChannelTest extends TestCase
         $mockSms = (new SMS(
             '5555555555',
             '5554443333',
-            'this is my message',
-            'text'
+            'this is my message'
         ));
 
         $vonage->shouldReceive('sms->send')


### PR DESCRIPTION
Without specifying the type, the default is unicode and messages are split at 70 chars according to the official documentation : https://developer.vonage.com/en/messaging/sms/guides/concatenation-and-encoding

The default type is defined in class `VonageMessage` message line 26 as `public $type = 'text';`

In screen below:
- in red, the initial message of 100 chars is split and billed 2 times because of the default type of [the vonage package v3](https://github.com/Vonage/vonage-php-sdk-core/blob/0ef4eeee503f378ffbd432cbef5e65f3b29d5d61/src/SMS/Message/SMS.php#L36) ([fixed in v4](https://github.com/Vonage/vonage-php-sdk-core/blob/ea849814e99464a1d232e1d348fbbd82ac1b3e6e/src/SMS/Message/SMS.php#L27))
- in green, the same message with the default type is billed normally

![Screenshot 2023-01-24 - 12-00-37@2x](https://user-images.githubusercontent.com/408237/214275769-2e6617fd-6e7b-4d49-9e29-282a12c53723.png)
