### PR TITLE
[3.x] Switch to `sms()` Client, improved GSM-7 Handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.0",
         "illuminate/notifications": "^8.0|^9.0",
         "illuminate/support": "^8.0|^9.0",
-        "vonage/client-core": "^3.0"
+        "vonage/client-core": "^4.0.2"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.2",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^8.0",
         "illuminate/notifications": "^8.0|^9.0|^10.0",
         "illuminate/support": "^8.0|^9.0|^10.0",
-        "vonage/client-core": "^4.0.2"
+        "vonage/client-core": "^4.0.4"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.2",

--- a/src/Channels/VonageSmsChannel.php
+++ b/src/Channels/VonageSmsChannel.php
@@ -5,6 +5,7 @@ namespace Illuminate\Notifications\Channels;
 use Illuminate\Notifications\Messages\VonageMessage;
 use Illuminate\Notifications\Notification;
 use Vonage\Client as VonageClient;
+use Vonage\SMS\Message\SMS;
 
 class VonageSmsChannel
 {
@@ -54,18 +55,18 @@ class VonageSmsChannel
             $message = new VonageMessage($message);
         }
 
-        $payload = [
-            'type' => $message->type,
-            'from' => $message->from ?: $this->from,
-            'to' => $to,
-            'text' => trim($message->content),
-            'client-ref' => $message->clientReference,
-        ];
+        $vonageSms = new SMS(
+            $to,
+            $message->from ?: $this->from,
+            trim($message->content)
+        );
+
+        $vonageSms->setClientRef($message->clientReference);
 
         if ($message->statusCallback) {
-            $payload['callback'] = $message->statusCallback;
+            $vonageSms->setDeliveryReceiptCallback($message->statusCallback);
         }
 
-        return ($message->client ?? $this->client)->message()->send($payload);
+        return ($message->client ?? $this->client)->sms()->send($vonageSms);
     }
 }

--- a/src/Channels/VonageSmsChannel.php
+++ b/src/Channels/VonageSmsChannel.php
@@ -41,7 +41,7 @@ class VonageSmsChannel
      *
      * @param  mixed  $notifiable
      * @param  \Illuminate\Notifications\Notification  $notification
-     * @return \Vonage\Message\Message
+     * @return \Vonage\SMS\Collection|null
      */
     public function send($notifiable, Notification $notification)
     {
@@ -58,7 +58,8 @@ class VonageSmsChannel
         $vonageSms = new SMS(
             $to,
             $message->from ?: $this->from,
-            trim($message->content)
+            trim($message->content),
+            $message->type
         );
 
         $vonageSms->setClientRef($message->clientReference);

--- a/tests/Unit/Channels/VonageSmsChannelTest.php
+++ b/tests/Unit/Channels/VonageSmsChannelTest.php
@@ -2,6 +2,7 @@
 
 namespace Illuminate\Notifications\Tests\Unit\Channels;
 
+use Hamcrest\Core\IsEqual;
 use Illuminate\Notifications\Channels\VonageSmsChannel;
 use Illuminate\Notifications\Messages\VonageMessage;
 use Illuminate\Notifications\Notifiable;
@@ -10,6 +11,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 use Vonage\Client;
+use Vonage\SMS\Message\SMS;
 
 class VonageSmsChannelTest extends TestCase
 {
@@ -24,14 +26,14 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'text',
-                'from' => '4444444444',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '',
-            ])
+        $mockSms = (new SMS(
+            '5555555555',
+            '4444444444',
+            'this is my message'
+        ));
+
+        $vonage->shouldReceive('sms->send')
+            ->with(IsEqual::equalTo($mockSms))
             ->once();
 
         $channel->send($notifiable, $notification);
@@ -40,14 +42,12 @@ class VonageSmsChannelTest extends TestCase
     public function testSmsIsSentViaVonageWithCustomClient()
     {
         $customVonage = m::mock(Client::class);
-        $customVonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'text',
-                'from' => '4444444444',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '',
-            ])
+        $customVonage->shouldReceive('sms->send')
+            ->with(IsEqual::equalTo(new SMS(
+                '5555555555',
+                '4444444444',
+                'this is my message'
+            )))
             ->once();
 
         $notification = new NotificationVonageSmsChannelTestCustomClientNotification($customVonage);
@@ -57,7 +57,7 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldNotReceive('message->send');
+        $vonage->shouldNotReceive('sms->send');
 
         $channel->send($notifiable, $notification);
     }
@@ -71,14 +71,14 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'unicode',
-                'from' => '5554443333',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '',
-            ])
+        $mockSms = (new SMS(
+            '5555555555',
+            '5554443333',
+            'this is my message'
+        ));
+
+        $vonage->shouldReceive('sms->send')
+            ->with(IsEqual::equalTo($mockSms))
             ->once();
 
         $channel->send($notifiable, $notification);
@@ -87,14 +87,16 @@ class VonageSmsChannelTest extends TestCase
     public function testSmsIsSentViaVonageWithCustomFromAndClient()
     {
         $customVonage = m::mock(Client::class);
-        $customVonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'unicode',
-                'from' => '5554443333',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '',
-            ])
+
+        $mockSms = new SMS(
+            '5555555555',
+            '5554443333',
+            'this is my message',
+            'unicode'
+        );
+
+        $customVonage->shouldReceive('sms->send')
+            ->with(IsEqual::equalTo($mockSms))
             ->once();
 
         $notification = new NotificationVonageSmsChannelTestCustomFromAndClientNotification($customVonage);
@@ -104,7 +106,7 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldNotReceive('message->send');
+        $vonage->shouldNotReceive('sms->send');
 
         $channel->send($notifiable, $notification);
     }
@@ -118,14 +120,17 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'unicode',
-                'from' => '5554443333',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '11',
-            ])
+        $mockSms = new SMS(
+            '5555555555',
+            '5554443333',
+            'this is my message',
+            'unicode'
+        );
+
+        $mockSms->setClientRef('11');
+
+        $vonage->shouldReceive('sms->send')
+            ->with(IsEqual::equalTo($mockSms))
             ->once();
 
         $channel->send($notifiable, $notification);
@@ -134,14 +139,18 @@ class VonageSmsChannelTest extends TestCase
     public function testSmsIsSentViaVonageWithCustomClientFromAndClientRef()
     {
         $customVonage = m::mock(Client::class);
-        $customVonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'unicode',
-                'from' => '5554443333',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '11',
-            ])
+
+        $mockSms = new SMS(
+            '5555555555',
+            '5554443333',
+            'this is my message',
+            'unicode'
+        );
+
+        $mockSms->setClientRef('11');
+
+        $customVonage->shouldReceive('sms->send')
+            ->with(IsEqual::equalTo($mockSms))
             ->once();
 
         $notification = new NotificationVonageSmsChannelTestCustomClientFromAndClientRefNotification($customVonage);
@@ -151,7 +160,7 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldNotReceive('message->send');
+        $vonage->shouldNotReceive('sms->send');
 
         $channel->send($notifiable, $notification);
     }
@@ -165,16 +174,17 @@ class VonageSmsChannelTest extends TestCase
             $vonage = m::mock(Client::class), '4444444444'
         );
 
-        $vonage->shouldReceive('message->send')
-            ->with([
-                'type' => 'text',
-                'from' => '4444444444',
-                'to' => '5555555555',
-                'text' => 'this is my message',
-                'client-ref' => '',
-                'callback' => 'https://example.com',
-            ])
-            ->once();
+        $mockSms = (new SMS(
+            '5555555555',
+            '4444444444',
+            'this is my message'
+        ));
+
+        $mockSms->setDeliveryReceiptCallback('https://example.com');
+
+        $vonage->shouldReceive('sms->send')
+               ->with(IsEqual::equalTo($mockSms))
+               ->once();
 
         $channel->send($notifiable, $notification);
     }
@@ -269,7 +279,6 @@ class NotificationVonageSmsChannelTestCallback extends Notification
 {
     public function toVonage($notifiable)
     {
-        return (new VonageMessage('this is my message'))
-            ->statusCallback('https://example.com');
+        return (new VonageMessage('this is my message'))->statusCallback('https://example.com');
     }
 }

--- a/tests/Unit/Channels/VonageSmsChannelTest.php
+++ b/tests/Unit/Channels/VonageSmsChannelTest.php
@@ -29,12 +29,36 @@ class VonageSmsChannelTest extends TestCase
         $mockSms = (new SMS(
             '5555555555',
             '4444444444',
-            'this is my message'
+            'this is my message',
+            'text'
         ));
 
         $vonage->shouldReceive('sms->send')
             ->with(IsEqual::equalTo($mockSms))
             ->once();
+
+        $channel->send($notifiable, $notification);
+    }
+
+    public function testSmsWillSendAsUnicode()
+    {
+        $notification = new NotificationVonageUnicodeSmsChannelTestNotification;
+        $notifiable = new NotificationVonageSmsChannelTestNotifiable;
+
+        $channel = new VonageSmsChannel(
+            $vonage = m::mock(Client::class), '4444444444'
+        );
+
+        $mockSms = (new SMS(
+            '5555555555',
+            '4444444444',
+            'this is my message',
+            'unicode'
+        ));
+
+        $vonage->shouldReceive('sms->send')
+               ->with(IsEqual::equalTo($mockSms))
+               ->once();
 
         $channel->send($notifiable, $notification);
     }
@@ -92,7 +116,6 @@ class VonageSmsChannelTest extends TestCase
             '5555555555',
             '5554443333',
             'this is my message',
-            'unicode'
         );
 
         $customVonage->shouldReceive('sms->send')
@@ -124,7 +147,6 @@ class VonageSmsChannelTest extends TestCase
             '5555555555',
             '5554443333',
             'this is my message',
-            'unicode'
         );
 
         $mockSms->setClientRef('11');
@@ -144,7 +166,6 @@ class VonageSmsChannelTest extends TestCase
             '5555555555',
             '5554443333',
             'this is my message',
-            'unicode'
         );
 
         $mockSms->setClientRef('11');
@@ -210,6 +231,14 @@ class NotificationVonageSmsChannelTestNotification extends Notification
     }
 }
 
+class NotificationVonageUnicodeSmsChannelTestNotification extends Notification
+{
+    public function toVonage($notifiable)
+    {
+        return (new VonageMessage('this is my message'))->unicode();
+    }
+}
+
 class NotificationVonageSmsChannelTestCustomClientNotification extends Notification
 {
     private $client;
@@ -229,7 +258,7 @@ class NotificationVonageSmsChannelTestCustomFromNotification extends Notificatio
 {
     public function toVonage($notifiable)
     {
-        return (new VonageMessage('this is my message'))->from('5554443333')->unicode();
+        return (new VonageMessage('this is my message'))->from('5554443333');
     }
 }
 
@@ -244,7 +273,7 @@ class NotificationVonageSmsChannelTestCustomFromAndClientNotification extends No
 
     public function toVonage($notifiable)
     {
-        return (new VonageMessage('this is my message'))->from('5554443333')->unicode()->usingClient($this->client);
+        return (new VonageMessage('this is my message'))->from('5554443333')->usingClient($this->client);
     }
 }
 
@@ -252,7 +281,7 @@ class NotificationVonageSmsChannelTestCustomFromAndClientRefNotification extends
 {
     public function toVonage($notifiable)
     {
-        return (new VonageMessage('this is my message'))->from('5554443333')->unicode()->clientReference('11');
+        return (new VonageMessage('this is my message'))->from('5554443333')->clientReference('11');
     }
 }
 
@@ -269,7 +298,6 @@ class NotificationVonageSmsChannelTestCustomClientFromAndClientRefNotification e
     {
         return (new VonageMessage('this is my message'))
             ->from('5554443333')
-            ->unicode()
             ->clientReference('11')
             ->usingClient($this->client);
     }


### PR DESCRIPTION
This PR is a redone version of the previously merged #61, which was reverted because v4.0 of the Vonage Core SDK was not being pulled in. Subsequently, messages were defaulted to Unicode for encoding, resulting in more SMS deliveries to end devices.

This PR now pulls in 4.0.4 of the SDK which does the following:
* Uses the `sms()` client instead of the legacy `message()` client.
* Defaults your message type to `text` which is GSM-7 encoded
* Still enables the user to use the Laravel `unicode()` method to switch if needs be
* If you send a GSM-7-compatible text as unicode, it will *trigger an `E_USER_WARNING`* but no exception, advising you to use the preferred encoding type
* If you send a GSM-7 message that needs to be Unicode, it will *trigger an `E_USER_WARNING`* advising you that the end device is likely to have scrambled characters due to not using the preferred encoding type.

For users, if you are not sure of the encoding type for your Notification message, a static helper method is now available for you to check before sending the notification through the channel.

```\Vonage\SMS\Message\SMS::isGsm7($message);```

Vonage are committed to users and to Laravel itself to make the best developer experience possible. If there are questions or concerns, hit me up.