### PR TITLE
[3.x] feat: allow to customise the signature_method

### DIFF
--- a/src/Vonage.php
+++ b/src/Vonage.php
@@ -80,7 +80,7 @@ class Vonage
         $signatureCredentials = null;
 
         if ($signatureSecret = $this->config['signature_secret'] ?? null) {
-            $signatureCredentials = new SignatureSecret($this->config['api_key'], $signatureSecret);
+            $signatureCredentials = new SignatureSecret($this->config['api_key'], $signatureSecret, $this->config['signature_method'] ?? 'md5hash');
         }
 
         if ($basicCredentials && $signatureCredentials) {

--- a/src/VonageChannelServiceProvider.php
+++ b/src/VonageChannelServiceProvider.php
@@ -22,8 +22,6 @@ class VonageChannelServiceProvider extends ServiceProvider
         $this->app->singleton(Client::class, function ($app) {
             $config = $app['config']['vonage'];
 
-            $httpClient = null;
-
             if ($httpClient = $config['http_client'] ?? null) {
                 $httpClient = $app->make($httpClient);
             } elseif (! class_exists('GuzzleHttp\Client')) {

--- a/src/VonageChannelServiceProvider.php
+++ b/src/VonageChannelServiceProvider.php
@@ -22,6 +22,8 @@ class VonageChannelServiceProvider extends ServiceProvider
         $this->app->singleton(Client::class, function ($app) {
             $config = $app['config']['vonage'];
 
+            $httpClient = null;
+
             if ($httpClient = $config['http_client'] ?? null) {
                 $httpClient = $app->make($httpClient);
             } elseif (! class_exists('GuzzleHttp\Client')) {


### PR DESCRIPTION
Hi,

Vonage allows us to customise the signature method (algo) through their dashboard (see screenshot), the default value is set to `HMAC_SHA256`.

This package was hard coded to use `md5hash`, this PR introduce a new config key `signature_method` which allows us to override the parameter.
![Web capture_30-4-2023_10815_dashboard nexmo com](https://user-images.githubusercontent.com/6111524/235335798-1275ad61-1998-4731-bf47-4da19af84e83.jpeg)

Vonage uses this algorithm to sign the incoming webhooks as well as outgoing SMS via the SDK.


PS.
 I have kept backward compatibility, the default algo in sdk is still the same. 
