### PR TITLE
Fix docblock

### DIFF
--- a/src/Messages/VonageMessage.php
+++ b/src/Messages/VonageMessage.php
@@ -124,7 +124,7 @@ class VonageMessage
     /**
      * Set the Vonage client instance.
      *
-     * @param  \Vonage\Client  $clientReference
+     * @param  \Vonage\Client  $client
      * @return $this
      */
     public function usingClient($client)


### PR DESCRIPTION
The parameter name in the docblock differs from that in the method.